### PR TITLE
Create pools.pp

### DIFF
--- a/manifests/pools.pp
+++ b/manifests/pools.pp
@@ -1,0 +1,19 @@
+# (C) Copyright 2015 Hewlett Packard Enterprise Development LP 
+#
+# Author: Shivendra Ashish <shivendra.ashish@hpe.com>
+#
+# == Class: ceph::pools
+#
+# Class wrapper for the benefit of scenario_node_terminus
+#
+# === Parameters:
+#
+# [*args*] A Ceph pools config hash
+#   Mandatory.
+#
+# [*defaults*] A config hash
+#   Optional. Defaults to an empty hash
+#
+class ceph::pools($args, $defaults = {}) {
+  create_resources(ceph::pool, $args, $defaults)
+}


### PR DESCRIPTION
While deploying ceph using puppet, if we want multiple pools to be created, it is not supported currently.
To support it, we need to have a new class where we can create multiple pools based on definition we have in pool.pp
